### PR TITLE
change: use SONAR_PROJECT_KEY and SONAR_ORGANIZATION env vars in build

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -1,5 +1,6 @@
 name: "Sonar Cloud Analyze"
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -33,4 +34,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_ORGANIZATION: ${{ vars.SONAR_ORGANIZATION }}
+          SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY }}
         run: ./gradlew build sonarqube --info


### PR DESCRIPTION
The new repos will have these vars set. For now the build falls back to the previous values, if the variables are not set.