### PR TITLE
chore(helm): enable filesystem for EDC instances

### DIFF
--- a/charts/traceability-foss-backend/values-dev.yaml
+++ b/charts/traceability-foss-backend/values-dev.yaml
@@ -200,6 +200,9 @@ irs-edc-consumer:
 
     namespace: product-traceability-foss
 
+    securityContext:
+      readOnlyRootFilesystem: false
+
     image:
       tag: "0.1.2"
 
@@ -306,6 +309,9 @@ irs-edc-consumer:
     fullnameOverride: "tracex-consumer-dataplane"
 
     namespace: product-traceability-foss
+
+    securityContext:
+      readOnlyRootFilesystem: false
 
     image:
       tag: "0.1.2"

--- a/charts/traceability-foss-backend/values-int.yaml
+++ b/charts/traceability-foss-backend/values-int.yaml
@@ -187,6 +187,9 @@ irs-edc-consumer:
 
     namespace: product-traceability-foss
 
+    securityContext:
+      readOnlyRootFilesystem: false
+
     auth:
       postgresPassword: <path:traceability-foss/data/int/edc/database#password>
       username: <path:traceability-foss/data/int/edc/database#user>
@@ -309,6 +312,9 @@ irs-edc-consumer:
 
     image:
       tag: "0.1.2"
+
+    securityContext:
+      readOnlyRootFilesystem: false
 
     ingresses:
       - enabled: true

--- a/charts/traceability-foss-backend/values-test-dev.yaml
+++ b/charts/traceability-foss-backend/values-test-dev.yaml
@@ -188,6 +188,9 @@ irs-edc-consumer:
     nameOverride: "tracex-test-consumer-edc-postgresql"
     fullnameOverride: "tracex-test-consumer-edc-postgresql"
 
+    securityContext:
+      readOnlyRootFilesystem: false
+
     namespace: product-traceability-foss
 
     auth:
@@ -309,6 +312,9 @@ irs-edc-consumer:
     fullnameOverride: "tracex-test-consumer-dataplane"
 
     namespace: product-traceability-foss
+
+    securityContext:
+      readOnlyRootFilesystem: false
 
     image:
       tag: "0.1.2"

--- a/infrastructure/edc-provider/values-dev-test.yaml
+++ b/infrastructure/edc-provider/values-dev-test.yaml
@@ -25,6 +25,9 @@ edc-controlplane:
     repository: "ghcr.io/catenax-ng/product-edc/edc-controlplane-postgresql-hashicorp-vault"
     tag: "0.1.2"
 
+  securityContext:
+    readOnlyRootFilesystem: false
+
   ingresses:
     - enabled: true
       hostname: "trace-x-test-edc.dev.demo.catena-x.net"
@@ -113,6 +116,9 @@ edc-dataplane:
   image:
     repository: "ghcr.io/catenax-ng/product-edc/edc-dataplane-hashicorp-vault"
     tag: "0.1.2"
+
+  securityContext:
+    readOnlyRootFilesystem: false
 
   ingresses:
     - enabled: true

--- a/infrastructure/edc-provider/values-dev.yaml
+++ b/infrastructure/edc-provider/values-dev.yaml
@@ -25,6 +25,9 @@ edc-controlplane:
     repository: "ghcr.io/catenax-ng/product-edc/edc-controlplane-postgresql-hashicorp-vault"
     tag: "0.1.2"
 
+  securityContext:
+    readOnlyRootFilesystem: false
+
   ingresses:
     - enabled: true
       hostname: "trace-x-edc.dev.demo.catena-x.net"
@@ -113,6 +116,9 @@ edc-dataplane:
   image:
     repository: "ghcr.io/catenax-ng/product-edc/edc-dataplane-hashicorp-vault"
     tag: "0.1.2"
+
+  securityContext:
+    readOnlyRootFilesystem: false
 
   ingresses:
     - enabled: true


### PR DESCRIPTION
There is an error log about a read-only filesystem. Enable writing for larger messages.