### PR TITLE
chore(helm): switch default registry to catenax-ng

### DIFF
--- a/charts/traceability-foss-backend/values.yaml
+++ b/charts/traceability-foss-backend/values.yaml
@@ -5,8 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/eclipse-tractusx/traceability-foss-backend
-  pullPolicy: IfNotPresent
+  repository: ghcr.io/catenax-ng/tx-traceability-foss-backend
+  pullPolicy: Always
 
 ##
 ## Image pull secret to create to obtain the container image


### PR DESCRIPTION
eclipse-tractusx has no public registry.