### PR TITLE
chore: revert "Update edc provider configuration (#212)"

### DIFF
--- a/infrastructure/edc-provider/values-dev-test.yaml
+++ b/infrastructure/edc-provider/values-dev-test.yaml
@@ -61,14 +61,14 @@ edc-controlplane:
       edc.receiver.http.endpoint=https://traceability-test.dev.demo.catena-x.net/api/callback/endpoint-data-reference
 
       edc.transfer.dataplane.sync.endpoint=http://tracex-test-edc-provider-edc-dataplane:8185/api/public
-      edc.transfer.proxy.endpoint=https://trace-x-test-edc-dataplane.dev.demo.catena-x.net/api/public/
+      edc.transfer.proxy.endpoint=https://trace-x-test-edc-dataplane.dev.demo.catena-x.net/api/public
       edc.transfer.proxy.token.signer.privatekey.alias=token-signer-cert-key-dev
       edc.transfer.proxy.token.verifier.publickey.alias=token-signer-cert-dev
 
       edc.dataplane.selector.consumer.url=http://tracex-test-edc-provider-edc-dataplane:9999/api/dataplane/control
       edc.dataplane.selector.consumer.sourcetypes=HttpData
       edc.dataplane.selector.consumer.destinationtypes=HttpProxy
-      edc.dataplane.selector.consumer.properties={ "publicApiUrl": "http://tracex-test-edc-provider-edc-dataplane:8185/api/public/" }
+      edc.dataplane.selector.consumer.properties={ "publicApiUrl": "http://tracex-test-edc-provider-edc-dataplane:8185/api/public" }
 
       edc.oauth.client.id=3A:F4:B9:17:B7:01:BC:4D:A7:8B:58:19:18:30:7F:65:30:BB:90:62:keyid:3A:F4:B9:17:B7:01:BC:4D:A7:8B:58:19:18:30:7F:65:30:BB:90:62
       edc.oauth.public.key.alias=daps-cert-edc-test-provider-dev

--- a/infrastructure/edc-provider/values-dev.yaml
+++ b/infrastructure/edc-provider/values-dev.yaml
@@ -61,14 +61,14 @@ edc-controlplane:
       edc.receiver.http.endpoint=http://tracex-edc-provider-edc-controlplane:8080/api/service/pull
 
       edc.transfer.dataplane.sync.endpoint=http://tracex-edc-provider-edc-dataplane:8185/api/public
-      edc.transfer.proxy.endpoint=https://trace-x-edc-dataplane.dev.demo.catena-x.net/api/public/
+      edc.transfer.proxy.endpoint=https://trace-x-edc-dataplane.dev.demo.catena-x.net/api/public
       edc.transfer.proxy.token.signer.privatekey.alias=token-signer-cert-key-dev
       edc.transfer.proxy.token.verifier.publickey.alias=token-signer-cert-dev
 
       edc.dataplane.selector.consumer.url=http://tracex-edc-provider-edc-dataplane:9999/api/dataplane/control
       edc.dataplane.selector.consumer.sourcetypes=HttpData
       edc.dataplane.selector.consumer.destinationtypes=HttpProxy
-      edc.dataplane.selector.consumer.properties={ "publicApiUrl": "http://tracex-edc-provider-edc-dataplane:8185/api/public/" }
+      edc.dataplane.selector.consumer.properties={ "publicApiUrl": "http://tracex-edc-provider-edc-dataplane:8185/api/public" }
 
       edc.oauth.client.id=60:99:BC:FC:9B:F9:5D:58:C4:94:1D:02:65:3E:88:B6:F9:C7:23:B3:keyid:60:99:BC:FC:9B:F9:5D:58:C4:94:1D:02:65:3E:88:B6:F9:C7:23:B3
       edc.oauth.public.key.alias=daps-cert-edc-provider-dev


### PR DESCRIPTION
The provider EDC must not have the trailing '/' in the dataplane URL. Otherwise, data fetching does not work. The consumer EDC needs that trailing '/', so notifications can work.

This reverts commit 6d6f0ae4c692d9c446e32a807996be35ed9e0079.